### PR TITLE
Fix rc build with clang++ and libc++ on Linux

### DIFF
--- a/res/rc.cc
+++ b/res/rc.cc
@@ -104,7 +104,7 @@ class optional {
 }  // std
 #endif
 
-#if !defined(_MSC_VER) && !defined(__linux__)
+#if !defined(_MSC_VER) && __cplusplus >= 201402L
 #include <string_view>
 #else
 namespace std {


### PR DESCRIPTION
I was attempting to build `rc` on Linux with `clang++ -stdlib=libc++`, and encountered the following error:
```
$ /opt/llvm/bin/clang++ --version
clang version 19.1.2 (/home/runner/work/llvm-project/llvm-project/clang 7ba7d8e2f7b6445b60679da826210cdde29eaf8b)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /opt/llvm/bin

$ /opt/llvm/bin/clang++ -stdlib=libc++ -std=c++14 -fuse-ld=lld -Wall -Wno-c++11-narrowing rc.cc -o rc 
rc.cc:140:24: error: reference to 'string_view' is ambiguous
  140 | template<> struct hash<string_view> {
      |                        ^
/opt/llvm/bin/../include/c++/v1/__fwd/string_view.h:25:33: note: candidate found by name lookup is 'std::__1::string_view'
   25 | typedef basic_string_view<char> string_view;
      |                                 ^
rc.cc:112:7: note: candidate found by name lookup is 'std::fundamentals_v1::string_view'
  112 | class string_view {
      |       ^
[more such errors follow]
```

Removing the `!defined(__linux__)` condition, allowing the compiler to see the `<string_view>` header, leads to a successful build. As that condition appears to have been added to support older Linux systems, I replaced it with a check for C++14. (Please let me know if this condition should be written differently.)